### PR TITLE
Fix: correct struct field mapping in Jinja2Value (replace nfields with fieldnames)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Jinja2Cpp"
 uuid = "53d8605c-dcf1-482a-b927-58e959abfe3c"
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 jinja2cppwrapper_jll = "1834a480-2153-5a5f-b716-e106e053fa41"

--- a/src/Jinja2Value.jl
+++ b/src/Jinja2Value.jl
@@ -61,7 +61,7 @@ end
     return check_value_null(handle)
 end
 
-@inline function jinja_value(::Jinja2BoolType, value::Bool)   # ← не трогаю
+@inline function jinja_value(::Jinja2BoolType, value::Bool)
     handle = jinja2cpp_value_create_int(value)
     return check_value_null(handle)
 end
@@ -104,7 +104,7 @@ end
 end
 
 @inline function jinja_value(::Jinja2CustomType, value)
-    handle = _jinja_map(_fieldpairs(value))   # ← вместо nfields()
+    handle = _jinja_map(_fieldpairs(value))
     map_handle = jinja2cpp_value_create_map(handle)
     return check_value_null(map_handle)
 end

--- a/src/Jinja2Value.jl
+++ b/src/Jinja2Value.jl
@@ -2,29 +2,29 @@
 
 abstract type Jinja2ValueType end
 
-struct Jinja2StringType  <: Jinja2ValueType end
+struct Jinja2StringType <: Jinja2ValueType end
 struct Jinja2IntegerType <: Jinja2ValueType end
-struct Jinja2BoolType    <: Jinja2ValueType end
-struct Jinja2DoubleType  <: Jinja2ValueType end
-struct Jinja2ListType    <: Jinja2ValueType end
-struct Jinja2MapType     <: Jinja2ValueType end
-struct Jinja2EmptyType   <: Jinja2ValueType end
-struct Jinja2CustomType  <: Jinja2ValueType end
+struct Jinja2BoolType <: Jinja2ValueType end
+struct Jinja2DoubleType <: Jinja2ValueType end
+struct Jinja2ListType <: Jinja2ValueType end
+struct Jinja2MapType <: Jinja2ValueType end
+struct Jinja2EmptyType <: Jinja2ValueType end
+struct Jinja2CustomType <: Jinja2ValueType end
 
 @inline Jinja2ValueType(::T) where {T} = Jinja2ValueType(T)
 @inline Jinja2ValueType(::Type{<:AbstractString}) = Jinja2StringType()
-@inline Jinja2ValueType(::Type{<:Symbol})        = Jinja2StringType()
-@inline Jinja2ValueType(::Type{<:Integer})       = Jinja2IntegerType()
-@inline Jinja2ValueType(::Type{<:Bool})          = Jinja2IntegerType()
+@inline Jinja2ValueType(::Type{<:Symbol}) = Jinja2StringType()
+@inline Jinja2ValueType(::Type{<:Integer}) = Jinja2IntegerType()
+@inline Jinja2ValueType(::Type{<:Bool}) = Jinja2IntegerType()
 @inline Jinja2ValueType(::Type{<:AbstractFloat}) = Jinja2DoubleType()
-@inline Jinja2ValueType(::Type{<:Nothing})       = Jinja2EmptyType()
-@inline Jinja2ValueType(::Type{<:Missing})       = Jinja2EmptyType()
-@inline Jinja2ValueType(::Type{<:AbstractVector})= Jinja2ListType()
-@inline Jinja2ValueType(::Type{<:AbstractSet})   = Jinja2ListType()
-@inline Jinja2ValueType(::Type{<:Tuple})         = Jinja2ListType()
-@inline Jinja2ValueType(::Type{<:AbstractDict})  = Jinja2MapType()
-@inline Jinja2ValueType(::Type{<:NamedTuple})    = Jinja2MapType()
-@inline Jinja2ValueType(::Type{<:Any})           = Jinja2CustomType()
+@inline Jinja2ValueType(::Type{<:Nothing}) = Jinja2EmptyType()
+@inline Jinja2ValueType(::Type{<:Missing}) = Jinja2EmptyType()
+@inline Jinja2ValueType(::Type{<:AbstractVector}) = Jinja2ListType()
+@inline Jinja2ValueType(::Type{<:AbstractSet}) = Jinja2ListType()
+@inline Jinja2ValueType(::Type{<:Tuple}) = Jinja2ListType()
+@inline Jinja2ValueType(::Type{<:AbstractDict}) = Jinja2MapType()
+@inline Jinja2ValueType(::Type{<:NamedTuple}) = Jinja2MapType()
+@inline Jinja2ValueType(::Type{<:Any}) = Jinja2CustomType()
 
 @inline function check_value_null(handle)
     if handle === VALUE_NULL

--- a/src/Jinja2Value.jl
+++ b/src/Jinja2Value.jl
@@ -2,29 +2,29 @@
 
 abstract type Jinja2ValueType end
 
-struct Jinja2StringType <: Jinja2ValueType end
+struct Jinja2StringType  <: Jinja2ValueType end
 struct Jinja2IntegerType <: Jinja2ValueType end
-struct Jinja2BoolType <: Jinja2ValueType end
-struct Jinja2DoubleType <: Jinja2ValueType end
-struct Jinja2ListType <: Jinja2ValueType end
-struct Jinja2MapType <: Jinja2ValueType end
-struct Jinja2EmptyType <: Jinja2ValueType end
-struct Jinja2CustomType <: Jinja2ValueType end
+struct Jinja2BoolType    <: Jinja2ValueType end
+struct Jinja2DoubleType  <: Jinja2ValueType end
+struct Jinja2ListType    <: Jinja2ValueType end
+struct Jinja2MapType     <: Jinja2ValueType end
+struct Jinja2EmptyType   <: Jinja2ValueType end
+struct Jinja2CustomType  <: Jinja2ValueType end
 
 @inline Jinja2ValueType(::T) where {T} = Jinja2ValueType(T)
 @inline Jinja2ValueType(::Type{<:AbstractString}) = Jinja2StringType()
-@inline Jinja2ValueType(::Type{<:Symbol}) = Jinja2StringType()
-@inline Jinja2ValueType(::Type{<:Integer}) = Jinja2IntegerType()
-@inline Jinja2ValueType(::Type{<:Bool}) = Jinja2IntegerType()
+@inline Jinja2ValueType(::Type{<:Symbol})        = Jinja2StringType()
+@inline Jinja2ValueType(::Type{<:Integer})       = Jinja2IntegerType()
+@inline Jinja2ValueType(::Type{<:Bool})          = Jinja2IntegerType()
 @inline Jinja2ValueType(::Type{<:AbstractFloat}) = Jinja2DoubleType()
-@inline Jinja2ValueType(::Type{<:Nothing}) = Jinja2EmptyType()
-@inline Jinja2ValueType(::Type{<:Missing}) = Jinja2EmptyType()
-@inline Jinja2ValueType(::Type{<:AbstractVector}) = Jinja2ListType()
-@inline Jinja2ValueType(::Type{<:AbstractSet}) = Jinja2ListType()
-@inline Jinja2ValueType(::Type{<:Tuple}) = Jinja2ListType()
-@inline Jinja2ValueType(::Type{<:AbstractDict}) = Jinja2MapType()
-@inline Jinja2ValueType(::Type{<:NamedTuple}) = Jinja2MapType()
-@inline Jinja2ValueType(::Type{<:Any}) = Jinja2CustomType()
+@inline Jinja2ValueType(::Type{<:Nothing})       = Jinja2EmptyType()
+@inline Jinja2ValueType(::Type{<:Missing})       = Jinja2EmptyType()
+@inline Jinja2ValueType(::Type{<:AbstractVector})= Jinja2ListType()
+@inline Jinja2ValueType(::Type{<:AbstractSet})   = Jinja2ListType()
+@inline Jinja2ValueType(::Type{<:Tuple})         = Jinja2ListType()
+@inline Jinja2ValueType(::Type{<:AbstractDict})  = Jinja2MapType()
+@inline Jinja2ValueType(::Type{<:NamedTuple})    = Jinja2MapType()
+@inline Jinja2ValueType(::Type{<:Any})           = Jinja2CustomType()
 
 @inline function check_value_null(handle)
     if handle === VALUE_NULL
@@ -61,7 +61,7 @@ end
     return check_value_null(handle)
 end
 
-@inline function jinja_value(::Jinja2BoolType, value::Bool)
+@inline function jinja_value(::Jinja2BoolType, value::Bool)   # ← не трогаю
     handle = jinja2cpp_value_create_int(value)
     return check_value_null(handle)
 end
@@ -76,14 +76,20 @@ end
     return check_value_null(handle)
 end
 
+#__ helpers__
+
+@inline _fieldpairs(x) = ((String(n), getfield(x, n)) for n in fieldnames(typeof(x)))
+
 function _jinja_map(entries)
     handle = jinja2cpp_values_map_create()
     check_map_null(handle)
     for (key, value) in entries
-        jinja2cpp_values_map_set(handle, key, jinja_value(value))
+        jinja2cpp_values_map_set(handle, String(key), jinja_value(value))
     end
     return handle
 end
+
+#__ map & list values__
 
 @inline function jinja_value(::Jinja2MapType, entries::AbstractDict)
     handle = _jinja_map(entries)
@@ -98,8 +104,7 @@ end
 end
 
 @inline function jinja_value(::Jinja2CustomType, value)
-    T = typeof(value)
-    handle = _jinja_map(zip(fieldnames(T), (getfield(value, i) for i = 1:nfields(T))))
+    handle = _jinja_map(_fieldpairs(value))   # ← вместо nfields()
     map_handle = jinja2cpp_value_create_map(handle)
     return check_value_null(map_handle)
 end
@@ -117,8 +122,7 @@ end
 @inline jinja_value(value) = jinja_value(Jinja2ValueType(value), value)
 
 convert_to_jinja_map(entries::AbstractDict) = _jinja_map(entries)
-convert_to_jinja_map(entries::NamedTuple) = _jinja_map(pairs(entries))
+convert_to_jinja_map(entries::NamedTuple)   = _jinja_map(pairs(entries))
 function convert_to_jinja_map(value)
-    T = typeof(value)
-    return _jinja_map(zip(fieldnames(T), (getfield(value, i) for i = 1:nfields(T))))
+    return _jinja_map(_fieldpairs(value))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,6 +163,55 @@ end
         tmpl = Jinja2Template(template_source)
         rendered_output = jinja2_render(tmpl, Hello("Bob"))
         @test rendered_output == "Hello, Bob!"
+
+        @kwdef struct EpisodeDirectors
+            pilot::String = "David Lynch"
+            episode_1::String = "Duwayne Dunham"
+            episode_2::String = "David Lynch"
+            episode_3::String = "Tina Rathborne"
+            episode_4::String = "Tim Hunter"
+            episode_5::String = "Lesli Linka Glatter"
+            episode_6::String = "Caleb Deschanel"
+            episode_7::String = "Mark Frost"
+            episode_8::String = "David Lynch"
+            episode_9::String = "David Lynch"
+            episode_10::String = "Lesli Linka Glatter"
+            episode_11::String = "Todd Holland"
+            episode_12::String = "Graeme Clifford"
+            episode_13::String = "Lesli Linka Glatter"
+            episode_14::String = "David Lynch"
+            episode_15::String = "Caleb Deschanel"
+            episode_16::String = "Tim Hunter"
+            episode_17::String = "Tina Rathborne"
+            episode_18::String = "Duwayne Dunham"
+            episode_19::String = "Caleb Deschanel"
+            episode_20::String = "Todd Holland"
+            episode_21::String = "Uli Edel"
+            episode_22::String = "Diane Keaton"
+            episode_23::String = "Lesli Linka Glatter"
+            episode_24::String = "James Foley"
+            episode_25::String = "Duwayne Dunham"
+            episode_26::String = "Jonathan Sanger"
+            episode_27::String = "Stephen Gyllenhaal"
+            episode_28::String = "Tim Hunter"
+            episode_29::String = "David Lynch"
+        end
+        tmpl = Jinja2Template(join([ string(n, ": ", "{{",n,"}}") for n in fieldnames(EpisodeDirectors)], "\n"))
+        rendered_output = jinja2_render(tmpl, EpisodeDirectors())
+        @test count("David Lynch", rendered_output) == 6
+        @test count("Lesli Linka Glatter", rendered_output) == 4
+        @test count("Caleb Deschanel", rendered_output) == 3
+        @test count("Duwayne Dunham", rendered_output) == 3
+        @test count("Tim Hunter", rendered_output) == 3
+        @test count("Todd Holland", rendered_output) == 2
+        @test count("Tina Rathborne", rendered_output) == 2
+        @test count("Graeme Clifford", rendered_output) == 1
+        @test count("Mark Frost", rendered_output) == 1
+        @test count("Uli Edel", rendered_output) == 1
+        @test count("James Foley", rendered_output) == 1
+        @test count("Stephen Gyllenhaal", rendered_output) == 1
+        @test count("Diane Keaton", rendered_output) == 1
+        @test count("Jonathan Sanger", rendered_output) == 1
     end
 
     @testset "Case №9: Rendering with template variables as NamedTuple" begin


### PR DESCRIPTION
Fix: correct struct field mapping in Jinja2Value (replace nfields with fieldnames)

### Pull request checklist

- [x] Did you bump the project version?
- [x] Did you add a description to the Pull Request?
- [x] Did you add new tests?
- [x] Did you add reviewers?
