### PR TITLE
Fix LICENSE: change copyright holder to Betterhand AG

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 bhftbootcamp
+Copyright (c) 2024 Betterhand AG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Change copyright holder in LICENSE from `bhftbootcamp` to `Betterhand AG` to match the pattern used across all other repositories in the organization.
- The year (2024) is preserved as-is.