### PR TITLE
Fix Documentation.yml: add push branches trigger for dev docs

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -2,6 +2,7 @@ name: Documenter
 
 on:
   push:
+    branches: [master]
     tags: [v*]
   pull_request:
 


### PR DESCRIPTION
## Summary
- Add `branches: [master]` under the `push` trigger in the Documentation workflow.
- Without this trigger, dev documentation is never deployed on pushes to master — only stable docs (on tag pushes) and PR previews were being built.